### PR TITLE
Copy record's dict so we don't affect other formatters

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -59,7 +59,7 @@ class LogstashFormatter(logging.Formatter):
         fields.
         """
 
-        fields = record.__dict__
+        fields = record.__dict__.copy()
         
         if isinstance(record.msg, dict):
             fields.update(record.msg)


### PR DESCRIPTION
Create a copy of the LogRecord's dictionary before modifying it, otherwise other LogFormatters will not see the msg attribute.
