### PR TITLE
Convert tab to spaces

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -114,7 +114,7 @@ class LogstashFormatter(logging.Formatter):
         True
         """
         return dict(defaults.get('@fields', {}).items() + fields.items())
-    
+
 
 class LogstashFormatterV1(LogstashFormatter):
     """
@@ -140,7 +140,7 @@ class LogstashFormatterV1(LogstashFormatter):
         if 'exc_text' in fields and not fields['exc_text']:
             fields.pop('exc_text')
 
-	now = datetime.datetime.utcnow()
+            now = datetime.datetime.utcnow()
         base_log = {'@timestamp': now.strftime("%Y-%m-%dT%H:%M:%S") + ".%03d" % (now.microsecond / 1000) + "Z",
                     '@version': 1,
                     'source_host': self.source_host}


### PR DESCRIPTION
Fixed indents so there are no more tabs present. Python 2.7 is ok with the tab, but in Python 3 it is an error.
