### PR TITLE
Fixed #22 UnboundLocalError in LogstashFormatterV1 by unindenting the now declaration.

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -140,7 +140,7 @@ class LogstashFormatterV1(LogstashFormatter):
         if 'exc_text' in fields and not fields['exc_text']:
             fields.pop('exc_text')
 
-            now = datetime.datetime.utcnow()
+        now = datetime.datetime.utcnow()
         base_log = {'@timestamp': now.strftime("%Y-%m-%dT%H:%M:%S") + ".%03d" % (now.microsecond / 1000) + "Z",
                     '@version': 1,
                     'source_host': self.source_host}


### PR DESCRIPTION
Issue #22 has a simple fix. All I had to do was unindent the declaration of now so that it is always declared.
