### PR TITLE
Fix TypeError when using LogstashFormatter on Py3

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -113,7 +113,7 @@ class LogstashFormatter(logging.Formatter):
                 {'foo': 'one'}
         True
         """
-        return dict(defaults.get('@fields', {}).items() + fields.items())
+        return dict(list(defaults.get('@fields', {}).items()) + list(fields.items()))
 
 
 class LogstashFormatterV1(LogstashFormatter):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(*parts):
                        encoding="utf-8").read()
 
 setup(name='logstash_formatter',
-      version='0.5.8',
+      version='0.5.10',
       description='JSON formatter meant for logstash',
       long_description=read('README.rst'),
       url='https://github.com/exoscale/python-logstash-formatter',


### PR DESCRIPTION
When logging something using LogstashFormatter in python3, you get the following error:
TypeError: unsupported operand type(s) for +: 'dict_items' and 'dict_items'

To avoid that, casting both elements into _build_fields as list.
