### PR TITLE
Fix IndexError when log message contains positional placeholders

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -79,6 +79,8 @@ class LogstashFormatter(logging.Formatter):
             msg = msg.format(**fields)
         except KeyError:
             pass
+        except IndexError:
+            pass
 
         if 'msg' in fields:
             fields.pop('msg')
@@ -141,6 +143,8 @@ class LogstashFormatterV1(LogstashFormatter):
             try:
                 msg = msg.format(**fields)
             except KeyError:
+                pass
+            except IndexError:
                 pass
             fields['message'] = msg
 

--- a/tests/test_log_message_positional_placeholder.py
+++ b/tests/test_log_message_positional_placeholder.py
@@ -1,0 +1,40 @@
+import logging
+import StringIO
+import unittest
+
+import logstash_formatter
+
+
+class LogMessagePositionalPlaceholderTest(unittest.TestCase):
+
+    def setUp(self):
+        self.stream = StringIO.StringIO()
+        handler = logging.StreamHandler(self.stream)
+        handler.setFormatter(logstash_formatter.LogstashFormatterV1())
+        handler.setLevel(logging.DEBUG)
+        self.log = logging.getLogger('test')
+        self.log.addHandler(handler)
+
+    def assertLogMessage(self, msg):
+        self.assertTrue(
+            '"message": "{}"'.format(msg) in self.stream.getvalue())
+
+
+test_msgs = {
+    'normal_log_message': 'foo',
+    'implicit_positional_placeholder': '{}',
+    'explicit_positional_placeholder': '{0}'
+}
+
+
+def make_method(msg):
+
+    def test_msg(self):
+        self.log.debug(msg)
+        self.assertLogMessage(msg)
+
+    return test_msg
+
+
+for name, msg in test_msgs.items():
+    setattr(LogMessagePositionalPlaceholderTest, name, make_method(msg))


### PR DESCRIPTION
If the log message contains {} or {0} positional placeholders, an IndexError
will be raise when LogstashFormatter attempts to format the message, passing
only keyword arguments.

For example, this happens when using LogstashFormatter with boto.

This patch silently ignores IndexError and leaves the log message unchanged.