### PR TITLE
Fix msg formatting for LogstashFormatterV1 

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -141,7 +141,9 @@ class LogstashFormatterV1(LogstashFormatter):
             fields.update(msg)
 
         elif 'msg' in fields and 'message' not in fields:
-            msg = fields.pop('msg')
+            msg = record.getMessage()
+            fields.pop('msg')
+
             try:
                 msg = msg.format(**fields)
             except (KeyError, IndexError):


### PR DESCRIPTION
I think the original intention of exoscale/python-logstash-formatter#16 is to support how the python logger module uses the old style of formatting in strings like `logger.info('My user id is: %s', user_id)`. exoscale/python-logstash-formatter@a2833be isn't the correct fix as it uses the newer format() with {}.

It works fine for `LogstashFormatter` since it gets the message via `record.getMessage()` but `LogstashFormatterV1` gets the message directly from the fields: `msg = fields['msg']`.

This PR fixes `LogstashFormatterV1` so it will also get the msg via `record.getMessage()` which internally formats the message with the provided args in LogRecord.

### Example Code
```python
# Say user_id is 10
logger.info('My user id is: %s', user_id)
```

#### Expected output
`{'message': 'My user id is 10, ...}`

#### Actual output
`{'message': 'My user id is %s', ...}`