### PR TITLE
Gracefully fallback to %-style string formatting if .format() fails

### DIFF
--- a/logstash_formatter/__init__.py
+++ b/logstash_formatter/__init__.py
@@ -80,6 +80,13 @@ class LogstashFormatter(logging.Formatter):
 
         try:
             msg = msg.format(**fields)
+        except ValueError:
+            # Gracefully fallback to old-style `%` formatting.
+            # TODO: use `style` argument to constructor, see logging module
+            try:
+                msg = msg % fields
+            except (KeyError, IndexError):
+                pass
         except (KeyError, IndexError):
             pass
 
@@ -149,6 +156,13 @@ class LogstashFormatterV1(LogstashFormatter):
 
             try:
                 msg = msg.format(**fields)
+            except ValueError:
+                # Gracefully fallback to old-style `%` formatting.
+                # TODO: use `style` argument to constructor, see logging module
+                try:
+                    msg = msg % fields
+                except (KeyError, IndexError):
+                    pass
             except (KeyError, IndexError):
                 pass
             fields['message'] = msg


### PR DESCRIPTION
For compatibility with lots of code with %-like formatting in log messages, we need to provide a fallback to this formatting.

An example is Celery with the following code:

```
    success_msg = """\
        Task %(name)s[%(id)s] succeeded in %(runtime)ss: %(return_value)s
    """

...

        info(self.success_msg.strip(), {
                'id': self.id, 'name': self.name,
                'return_value': self.repr_result(ret_value),
                'runtime': runtime})

```

Provided solution is "quick&dirty" and the proper way to fix it is to use the `style` parameter in Formatter init.
