### PR TITLE
Allow more control of JSON output fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # python compiled files
 *.pyc
+
+# pycharm / other IDEs
+.idea

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ The LogstashFormatter may take the following named parameters:
 * ``fmt``: Config as a JSON string that supports:
 
   * ``extra``: provide extra fields always present in logs.
-  * ``source_host``: override source host name.
+  * ``source_host``: override source host name; set to ``null`` to exclude.
 
 * ``json_cls``: JSON encoder to forward to ``json.dump``.
 * ``json_default``: Default JSON representation for unknown types,
@@ -138,3 +138,10 @@ The following keys will be found in the output JSON:
      "funcName": "<module>",
      "levelname": "WARNING",
      "message": "foo"}
+
+Known issues
+------------
+
+The handlers which use the logstash formatters must be the first ones added to the logger.
+Otherwise the "classic message" example above won't work. Specifically, the "{account}" won't
+be interpolated into the message.


### PR DESCRIPTION
We'd like more control over the output. This PR adds a hook which we can override, or allows us to suppress the source_host using just a format.

Also fixed a small bug where the @timestamp was set to now() instead of record.created.